### PR TITLE
bugfix: use `present` instead of `installed`

### DIFF
--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -3,4 +3,4 @@
 - name: Install virtualbox
   package:
     name: virtualbox
-    state: installed
+    state: present

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -11,4 +11,4 @@
 - name: Install virtualbox
   package:
     name: VirtualBox-{{ virtualbox_version_redhat }}
-    state: installed
+    state: present


### PR DESCRIPTION
       [DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present'
       instead.. This feature will be removed in version 2.9. Deprecation warnings can
        be disabled by setting deprecation_warnings=False in ansible.cfg.